### PR TITLE
Device driver for OLED (128 x 64)

### DIFF
--- a/student/oled_plat_dev.c
+++ b/student/oled_plat_dev.c
@@ -1,0 +1,75 @@
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/spi/spi.h>
+#include <linux/slab.h>
+#include "oled_ssd1308_spi.h"
+
+
+struct oled_platform_data_t oled_platform_data = {
+	.spi = NULL,
+	.pixel_x = 128,
+	.pixel_y = 64,
+	.page_nr = 8,
+	.reset_pin = 114,
+	.ad_pin = 55,
+	.led1_pin = 48,
+	.led2_pin = 58,
+	.fb = NULL
+};
+
+struct spi_board_info oled_board_info[] = {
+	{
+		.modalias = "oled-ssd1308",
+		.platform_data = &oled_platform_data,
+		.mode = SPI_MODE_0,
+		.max_speed_hz = 5000000,
+		.bus_num = 1,     /* spidev1.X */
+		.chip_select = 0, /* spidevY.0 */
+		.mode = 0,
+	}
+};
+
+
+static int oled_plat_dev_init(void)
+{
+	struct spi_master *master;
+	struct spi_device *spi;
+
+#if 1
+	master = spi_busnum_to_master(oled_board_info[0].bus_num);
+	if (!master) {
+		printk(KERN_WARNING "%s: spi_busnum_to_master() failed~\n", __func__);
+		return -ENODEV;
+	}
+	
+	spi = spi_new_device(master, oled_board_info);
+	if (!spi) {
+		printk(KERN_WARNING "%s: spi_new_device() failed~\n", __func__);
+		return -ENOTTY;
+	}
+
+	oled_platform_data.spi = spi;
+	
+
+#else /* at booting stage, __init */
+	
+	spi_register_board_info(oled_board_info, ARRAY_SIZE(oled_board_info));
+	
+#endif
+	printk(KERN_WARNING "%s: complete\n", __func__);
+	return 0;
+}
+
+
+static void oled_plat_dev_exit(void)
+{
+	printk(KERN_INFO "%s\n", __func__);
+	spi_unregister_device(oled_platform_data.spi);
+}
+
+
+module_init(oled_plat_dev_init);
+module_exit(oled_plat_dev_exit);
+
+MODULE_LICENSE("GPL");

--- a/student/oled_ssd1308_ctrl.c
+++ b/student/oled_ssd1308_ctrl.c
@@ -1,0 +1,297 @@
+/**************************************************************
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  MISC category driver for test OLED-SSD1308
+ *
+ *
+ *  History:     ysh  7-25-2016          Create
+ *************************************************************/
+
+
+#include <linux/delay.h>
+#include <linux/gpio.h>
+#include <linux/spi/spi.h>
+#include <linux/err.h>
+#include "oled_ssd1308_spi.h"
+
+#undef pr_fmt
+#define pr_fmt(fmt) "%s:"fmt
+
+enum DataCmd_e {
+	eCommand,
+	eData
+};
+
+static int  _spi_tx(u8 byte);
+static int  _spi_tx_batch(u8 *pdata, ssize_t len);
+static void _set_dataMode(void);
+static void _set_cmdMode(void);
+static void _set_dc_pin(enum DataCmd_e data_cmd);
+static void _write_cmd(u8 cmd);
+static void _write_data_batch(u8 *pData, ssize_t len);
+static void _set_page_addr(u8 page);
+static void _set_lower_addr(u8 low);
+static void _set_high_addr(u8 high);
+static void _raise_reset(void);
+static void _release_reset(void);
+
+static struct oled_platform_data_t *pOLED;
+
+
+static int _spi_tx(u8 byte)
+{
+	int ret;
+	
+	if (IS_ERR(pOLED->spi))
+		return PTR_ERR(pOLED->spi);
+	
+	ret = spi_write(pOLED->spi, &byte, sizeof(u8));
+	if (ret)
+		printk(KERN_WARNING "%s: error\n", __func__);
+	
+	return ret;
+}
+
+
+static int _spi_tx_batch(u8 *pData, ssize_t len)
+{
+	int ret;
+
+	if (IS_ERR(pOLED->spi))
+		return PTR_ERR(pOLED->spi);
+	
+	ret = spi_write(pOLED->spi, pData, len);
+	if (ret)
+		printk(KERN_WARNING "%s: error\n", __func__);
+
+	return ret;
+}
+
+			 
+static void _set_dataMode(void)
+{
+	gpio_set_value(pOLED->ad_pin, 1);
+}
+
+
+static void _set_cmdMode(void)
+{
+	gpio_set_value(pOLED->ad_pin, 0);
+}
+
+
+static void _set_dc_pin(enum DataCmd_e data_cmd)
+{
+	if(data_cmd == eCommand)
+		_set_cmdMode();
+	else /* data_cmd == eData */
+		_set_dataMode();
+}
+
+
+static void _write_cmd(u8 cmd)
+{
+	_set_dc_pin(eCommand);
+	_spi_tx(cmd);
+}
+
+
+void _write_data_batch(u8 *pData, ssize_t len)
+{
+	_set_dc_pin(eData);
+	_spi_tx_batch(pData, len);
+}
+
+void oled_on()
+{
+	_write_cmd(0xafu);
+}
+
+
+void oled_off()
+{
+	_write_cmd(0xaeu);
+}
+
+
+static void _set_page_addr(u8 page)
+{
+	_write_cmd((page & 0x0fu) + 0xb0u);
+}
+
+
+static void _set_lower_addr(u8 low)
+{
+	_write_cmd(low & 0x0fu);
+}
+
+
+static void _set_high_addr(u8 high)
+{
+	_write_cmd((high & 0x0fu) + 0x10u);
+}
+
+static void _raise_reset()
+{
+	gpio_set_value(pOLED->reset_pin, 0);
+}
+
+
+static void _release_reset()
+{
+	gpio_set_value(pOLED->reset_pin, 1);
+}
+
+
+void oled_reset()
+{
+	_raise_reset();
+	mdelay(1);
+	_release_reset();
+
+
+	/* Sleep mode : AEh */
+	_write_cmd(0xaeu);		/* display off */
+
+	_write_cmd(0xd5u);		/* Set Display clocDivide Ratio/Oscillator Frequency */
+	_write_cmd(0x80u);		/* 105Hz */
+
+	_write_cmd(0xa8u);		/* Set Multiplex ratio */
+	_write_cmd(0x3fu);		/* Set 64 mux */
+
+	_write_cmd(0xd9u);		/* Set Pre-charge Period */
+	_write_cmd(0x22u);		/* Default value */
+
+	_write_cmd(0x20u);		/* Set Memory Addressing Mode */
+	_write_cmd(0x00u);		/* Default value */
+	
+	_write_cmd(0xa0u);		/* 0xa0: seg re-map 0-->127; 0xa1: seg re-map 127-->0 */
+	
+	_write_cmd(0xc0u);		/* 0xc0: com scan direction COM0-->COM(N-1); 0xc8: com scan direction COM(N-1)-->COM0 */
+	
+	_write_cmd(0xdau);		/* Set Com Pins Hardware Configuration */
+	_write_cmd(0x12u);		/* Default value */
+	
+	_write_cmd(0xadu);		/* External or Internal Iref Selection */
+	_write_cmd(0x00u);		/* 0x00: External Iref ; 0x10: Internal Iref*/
+	
+	_write_cmd(0x81u);		/* Set Contrast Control */
+	_write_cmd(0x50u);		/* 1..256£¬adjust in application */
+	
+	_write_cmd(0xb0u);		/* Set Page start Address for Page Addressing Monde */
+	
+	_write_cmd(0xd3u);		/* Set Display Offset */
+	_write_cmd(0x00u);		/* offset=0, The value is default */
+	
+	_write_cmd(0x21u);		/* Set Column Address */
+	_write_cmd(0x00u);		/* Column Start Address */
+	_write_cmd(0x7fu);		/* Column End Address */
+	
+	_write_cmd(0x22u);		/* Set Page Address */
+	_write_cmd(0x00u);		/* Page Start Address */
+	_write_cmd(0x07u);		/* Page End Address */
+	
+	_write_cmd(0x10u);		/* Set Higher Column Start Address for Page Addressing Mode */
+	_write_cmd(0u);                 /* Set Lower Column Start Address for Page Addressing Mode */
+	
+	_write_cmd(0x40u);		/* Set Display Start Line */
+	
+	_write_cmd(0xa6u);		/* 0xa6: Display Normal; 0xa7: Display Inverse */
+	
+	_write_cmd(0xa4u);		/* 0xa4: Resume to RAM content display; 0xa5: Display 0xa5, ignores RAM content */
+	
+	_write_cmd(0xdbu);		/* Set VCOMH Level */
+	_write_cmd(0x30u);		/* 0x00: 0.65Vcc; 0x20: 0.77Vcc; 0x30: 0.83Vcc */	
+	
+	oled_on();
+	printk(KERN_INFO "%s: complete\n", __func__);
+}
+
+
+void oled_flush()
+{
+	ssize_t
+		page,
+		page_nr,
+		pixel_x;
+	u8 *fb;
+	int i;
+
+	pr_debug("enter\n", __func__);
+	
+	page_nr = pOLED->page_nr;
+	pixel_x = pOLED->pixel_x;
+
+	if (pOLED->reverse_pixel) {
+		for (i=0; i<pOLED->fb_size; i++)
+			pOLED->fb_reverse[i] = ~pOLED->fb[i];
+		fb = pOLED->fb_reverse;
+	}
+	else
+		fb = pOLED->fb;
+
+	if (IS_ERR(fb)) {
+		printk(KERN_WARNING "%s: fb error\n", __func__);
+		return;
+	}
+
+	for(page=0; page<page_nr; page++)
+	{
+		_set_page_addr(page);
+		_set_lower_addr(0);
+		_set_high_addr(0);
+		_write_data_batch(fb + page * pixel_x, pixel_x);
+	}
+
+	pr_debug("exit\n", __func__);
+}
+
+
+void oled_paint(u8 byte)
+{
+	ssize_t
+		page,
+		page_offset,
+		pixel,
+		page_nr,
+		pixel_x;
+	u8 *fb;
+
+	// down_interruptible(&pOLED->sem);
+	pr_debug("enter\n", __func__);
+	
+	page_nr = pOLED->page_nr;
+	pixel_x = pOLED->pixel_x;
+	fb = pOLED->fb;
+
+	if (IS_ERR(fb)) {
+		printk(KERN_WARNING "%s: fb error\n", __func__);
+		return;
+	}
+	
+	for(page=0; page<page_nr; page++) {
+		page_offset = page * pixel_x;
+		pr_debug("page_offset: %d\n", __func__, page_offset);
+		for(pixel=0; pixel<pixel_x; pixel++)
+			fb[page_offset + pixel] = byte;
+	}
+	pr_debug("data copying done\n", __func__);
+	
+	// up(&pOLED->sem);
+	pr_debug("exit\n", __func__);
+}
+
+
+void oled_init(struct oled_platform_data_t *oled)
+{
+	pr_debug("enter\n", __func__);
+	pOLED = oled;
+	sema_init(&pOLED->sem, 1);
+	oled_reset();
+	pr_debug("exit\n", __func__);
+}

--- a/student/oled_ssd1308_gpio.c
+++ b/student/oled_ssd1308_gpio.c
@@ -1,0 +1,89 @@
+/**************************************************************
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  MISC category driver for test OLED-SSD1308
+ *
+ *
+ *  History:     ysh  7-29-2016          Create
+ *************************************************************/
+
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/delay.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/gpio.h>
+#include "oled_ssd1308_spi.h"
+
+
+#undef pr_fmt
+#define pr_fmt(fmt) "%s:"fmt
+
+
+struct gpio_t {
+	unsigned pin;
+	unsigned long flag;
+	char *label;
+};
+
+static struct gpio_t *oled_gpios = NULL;
+static struct oled_platform_data_t *pOLED = NULL;
+static ssize_t oled_gpio_nr = 0;
+
+int oled_init_gpios(struct oled_platform_data_t *);
+void oled_free_gpios(void);
+
+
+int oled_init_gpios(struct oled_platform_data_t *oled)
+{	
+	ssize_t i;
+	int err;
+	struct gpio_t gpios[] = {
+		{ oled->reset_pin, GPIOF_DIR_OUT, "OLED-Reset-Pin" },
+		{ oled->ad_pin,    GPIOF_DIR_OUT, "OLED-AD-Pin"    },
+		{ oled->led1_pin,  GPIOF_DIR_OUT, "LED1-Pin"       },
+		{ oled->led2_pin,  GPIOF_DIR_OUT, "LED2-Pin"       }
+	};
+	
+	pOLED = oled;
+	oled_gpio_nr = ARRAY_SIZE(gpios);
+	oled_gpios = kzalloc(sizeof gpios, GFP_KERNEL);
+	memcpy(oled_gpios, gpios, sizeof gpios);
+	
+	for (i=0; i<oled_gpio_nr; i++) {
+		struct gpio_t *io = &gpios[i];
+		err = gpio_request_one(io->pin, io->flag, io->label);
+		if (err)
+			printk(KERN_WARNING "%s: Request GPIO-%d failed~\n",
+			       __func__, io->pin);
+	}
+
+	gpio_set_value(oled->led1_pin, 0);
+	gpio_set_value(oled->led2_pin, 0);
+	pr_debug("\n", __func__);
+	return 0;
+}
+
+
+void oled_free_gpios()
+{	
+	ssize_t i;
+	ssize_t gpio_nr = oled_gpio_nr;
+	struct gpio_t *gpios = oled_gpios;
+	
+	gpio_set_value(pOLED->led1_pin, 1);
+	gpio_set_value(pOLED->led2_pin, 1);
+	
+	for (i=0; i<gpio_nr; i++)
+		gpio_free(gpios[i].pin);
+	
+	kfree(oled_gpios);
+	pr_debug("\n", __func__);
+}

--- a/student/oled_ssd1308_ioctl.h
+++ b/student/oled_ssd1308_ioctl.h
@@ -1,0 +1,31 @@
+/**************************************************************
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  
+ *
+ *
+ *  History:     ysh  7-29-2016          Create
+ *************************************************************/
+
+
+#ifndef __OLED_SSD1308_IOCTL_H
+#define __OLED_SSD1308_IOCTL_H
+
+
+#include <linux/ioctl.h>
+
+
+#define OLED_CLEAR    _IO(0xCE, 1)
+#define OLED_RESET    _IO(0xCE, 2)
+#define OLED_ON       _IO(0xCE, 3)
+#define OLED_OFF      _IO(0xCE, 4)
+#define OLED_FEED     _IOW(0xCE, 5, unsigned char)
+#define OLED_FLUSH_RATE _IOW(0xCE, 6, unsigned long)
+
+
+#endif /* __OLED_SSD1308_IOCTL_H */

--- a/student/oled_ssd1308_spi.c
+++ b/student/oled_ssd1308_spi.c
@@ -1,0 +1,474 @@
+/**************************************************************
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  MISC category driver for test OLED-SSD1308
+ *
+ *
+ *  History:     ysh  7-07-2016          Create
+ *************************************************************/
+
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/delay.h>
+#include <linux/sched.h>
+#include <linux/timer.h>
+#include <linux/miscdevice.h>
+#include <linux/slab.h>
+#include <linux/interrupt.h>
+#include <linux/string.h>
+#include <linux/spi/spi.h>
+#include <linux/uaccess.h>
+#include <linux/gpio.h>
+#include <asm/io.h>
+#include <asm/page.h>
+#include "oled_ssd1308_spi.h"
+#include "oled_ssd1308_ioctl.h"
+
+#undef pr_fmt
+#define pr_fmt(fmt) "%s: "fmt
+
+#define FLUSH_RATE_DEFAULT 200 /* ms */
+//#define __SINGLE_WQ
+#define __SHARED_QU
+//#define __TIMER
+
+#define PIXEL_X    128
+#define PIXEL_Y     64
+
+struct ssd1308_t {
+	wait_queue_head_t wait_q;
+	struct semaphore sem;
+	struct work_struct worker;
+	struct delayed_work dworker;
+	struct timer_list timer;
+	struct tasklet_struct tasklet;
+	struct workqueue_struct *wq;
+	int del_wq;
+	int worker_count;
+	int timer_count;
+	int tasklet_count;
+	unsigned long flush_rate_ms;
+	struct oled_platform_data_t *platform_data;
+};
+
+
+struct oled_platform_data_t OLED;
+extern int oled_init_gpios(struct oled_platform_data_t *oled);
+extern void oled_free_gpios(void);
+
+
+#ifdef __SINGLE_WQ
+static void worker_func(struct work_struct *pWork)
+{
+	struct ssd1308_t *ssd;
+	ssd = container_of(pWork, struct ssd1308_t, worker);
+
+	while (ssd->del_wq != 1) {
+		oled_flush();
+		msleep(ssd->flush_rate_ms);
+		// printk(KERN_WARNING "*fb : 0x%X\n", *ssd->platform_data->fb);
+	}
+	ssd->del_wq = 2;
+	pr_debug("exit, flush_rate: %ldms\n", __func__, ssd->flush_rate_ms);
+}
+
+#elif defined(__SHARED_QU)
+
+static void dworker_func(struct delayed_work *pWork)
+{
+	struct ssd1308_t *ssd;
+	ssd = container_of(pWork, struct ssd1308_t, dworker);
+
+	oled_flush();
+	if (ssd->del_wq == 1) {
+		pr_debug("receive killing message\n", __func__);
+		ssd->del_wq = 2;
+		return;
+	}
+	schedule_delayed_work(&ssd->dworker, ssd->flush_rate_ms * HZ / 1000);
+}
+#endif
+
+
+#ifdef __TIMER
+static void timer_func(unsigned long pSSD)
+{
+	struct ssd1308_t *ssd = (struct ssd1308_t*)pSSD;
+	unsigned long expired = jiffies + HZ / 10;
+	ssd->timer_count++;
+	oled_flush();
+	mod_timer(&ssd->timer, expired);
+}
+#endif
+
+
+static ssize_t oled_ssd1308_write(struct file *filp, const char __user *buf, size_t count, loff_t *f_pos)
+{
+	struct ssd1308_t *ssd;
+	
+	ssd = (struct ssd1308_t*)filp->private_data;
+	if (down_interruptible(&ssd->sem)) {
+		pr_debug("interrupted", __func__);
+		return 0;
+	}
+
+#if 0
+	u8 b;
+	if (!get_user(b, buf)) {
+		printk(KERN_INFO "%s: count %d\n", __func__, count);
+		printk(KERN_INFO "%s: buf %s\n", __func__, buf);
+		printk(KERN_INFO "%s: user data %d\n", __func__, b);
+		oled_paint(b);
+		oled_flush();
+	}
+	
+#else
+	/*
+	 * Transform to hexidecimal
+	 */
+	#define BUF_SIZE 64
+	
+	int ret;
+	long pixel;
+	char str[BUF_SIZE];
+	size_t i;
+	u8 b;
+
+	if (count > BUF_SIZE - 1) {
+		printk(KERN_WARNING "%s: user string is too long\n", __func__);
+		goto _WRITE_DONE;
+	}
+
+	/*
+	 * Accept 0 ~ 9, assemble chars to a string
+	 */
+	for(i=0; i<count; i++) {
+		get_user(b, buf + i);
+		printk(KERN_INFO "buf[%d] : %d\n", i, b);
+		if (b >= '0' && b <= '9') {
+			str[i] = b;
+			continue;
+		}
+		str[i] = '\0';
+		break;
+	}
+	
+	ret = kstrtol(str, 0, &pixel);
+	if (ret == 0) {
+		printk(KERN_INFO "%s: pixel %x\n", __func__, pixel);
+		oled_paint((u8)pixel);
+		oled_flush();
+	}
+	else
+		printk(KERN_WARNING "%s: kstrtol failed~\n");
+
+#endif
+	
+_WRITE_DONE:
+	up(&ssd->sem);
+	return count;
+}
+
+
+static long oled_ssd1308_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+{
+	switch(cmd) {
+	case OLED_CLEAR:
+		oled_paint((u8)0);
+		break;
+		
+	case OLED_RESET:
+		oled_reset();
+		break;
+		
+	case OLED_ON:
+		oled_on();
+		break;
+		
+	case OLED_OFF:
+		oled_off();
+		break;
+		
+	case OLED_FEED:
+	{
+		u8 feed;
+		u8 __user *ptr = (void __user *)arg;
+		
+		if (get_user(feed, ptr))
+			return -EFAULT;
+		oled_paint(feed);
+	}
+	break;
+
+	case OLED_FLUSH_RATE:
+	{
+		struct ssd1308_t *ssd = (struct ssd1308_t*)filp->private_data;
+		pr_debug("New flush rate : %ldms\n", __func__, arg);
+		ssd->flush_rate_ms = arg;
+	}
+	break;
+		
+	default:
+		return -ENOTTY;
+	}
+	
+	pr_debug("cmd-%x\n", __func__, cmd);
+	return 0;
+}
+
+
+static int oled_ssd1308_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	struct ssd1308_t *ssd = (struct ssd1308_t*)filp->private_data;
+	struct oled_platform_data_t *oled = ssd->platform_data;
+	int ret;
+	phys_addr_t phys = virt_to_phys((void*)oled->fb);
+
+	pr_debug("enter\n", __func__);
+	pr_debug("oled->fb: %p\n", __func__, oled->fb);
+	pr_debug("oled->fb_size: %d\n", __func__, oled->fb_size);
+	pr_debug("virt_to_phys((void*)oled->fb) : %p >> PAGE_SHIFT : %p\n",
+		 __func__,
+		 phys,
+		 phys >> PAGE_SHIFT);
+	
+	pr_debug("vma->vm_end: %lx\n", __func__, vma->vm_end);
+	pr_debug("vma->vm_start: %lx\n", __func__, vma->vm_start);
+	pr_debug("size: %lu\n", __func__, vma->vm_end - vma->vm_start);
+	
+	ret = remap_pfn_range(vma,
+			      vma->vm_start,
+			      phys >> PAGE_SHIFT,
+			      vma->vm_end - vma->vm_start,
+			      vma->vm_page_prot);
+	if (ret < 0) {
+		printk(KERN_WARNING "%s: remap_pfn_range failed\n", __func__);
+		return -EIO;
+	}
+
+	pr_debug("exit\n", __func__);
+	return 0;
+}
+
+
+static int oled_ssd1308_open(struct inode *inode, struct file *filp)
+{
+	struct ssd1308_t *ssd;
+	
+	pr_debug("enter\n", __func__);
+	
+	/* Allocate memory to private data, and set memory to zero */
+	ssd = kzalloc(sizeof(struct ssd1308_t), GFP_KERNEL);
+	ssd->platform_data = &OLED;
+	filp->private_data = ssd;
+
+	sema_init(&ssd->sem, 1);
+
+	/* work queue */
+	ssd->del_wq = 0;
+	ssd->flush_rate_ms = FLUSH_RATE_DEFAULT;
+
+
+#ifdef __SINGLE_WQ
+	ssd->wq = create_singlethread_workqueue("oled-flush");
+	INIT_WORK(&ssd->worker, worker_func);
+	queue_work(ssd->wq, &ssd->worker);
+#endif
+
+#ifdef __SHARED_QU
+	INIT_DELAYED_WORK(&ssd->dworker, dworker_func);
+	schedule_delayed_work(&ssd->dworker, ssd->flush_rate_ms * HZ / 1000);
+	//INIT_WORK(&ssd->worker, worker_func);
+	//schedule_work(&ssd->worker);
+#endif
+
+#ifdef __TIMER
+	/* Init timer */
+	init_timer(&ssd->timer);
+	ssd->timer.function = timer_func;
+	ssd->timer.data = (unsigned long)ssd;
+	timeout = HZ / 10;
+	ssd->timer.expires = jiffies + timeout;
+	add_timer(&ssd->timer);
+	oled_paint(0xff);
+#endif
+
+	pr_debug("exit\n", __func__);
+	return 0;
+}
+
+static int oled_ssd1308_close(struct inode *inode, struct file *filp)
+{
+	struct ssd1308_t *ssd;
+
+	ssd = (struct ssd1308_t*)filp->private_data;
+	pr_debug("enter\n", __func__);
+
+#ifdef __TIMER
+	del_timer_sync(&ssd->timer);
+#endif
+
+
+#ifdef  __SINGLE_WQ
+	ssd->del_wq = 1;
+	msleep(ssd->flush_rate_ms);
+
+	while (ssd->del_wq != 2)
+		msleep(ssd->flush_rate_ms);
+	
+	flush_workqueue(ssd->wq);
+	destroy_workqueue(ssd->wq);
+	
+#elif defined(__SHARED_QU)
+	ssd->del_wq = 1;
+	while (!cancel_delayed_work(&ssd->dworker)) {
+		msleep(ssd->flush_rate_ms);
+	}
+	pr_debug("delayed work has been canceled\n", __func__);
+#endif
+	
+	kfree(filp->private_data);
+	pr_debug("exit\n", __func__);
+	return 0;
+}
+
+static struct file_operations oled_fops = {
+	.owner = THIS_MODULE,
+	.write = oled_ssd1308_write,
+	.unlocked_ioctl = oled_ssd1308_ioctl,
+	.mmap = oled_ssd1308_mmap,
+	.open = oled_ssd1308_open,
+	.release = oled_ssd1308_close
+};
+
+
+static struct miscdevice oled_ssd1308_miscdev = {
+	.minor = 197, /* Refer to miscdev.h */
+	.name = "oled-ssd1308",
+	.fops = &oled_fops
+};
+
+
+static ssize_t reverse_show(struct class *class, struct class_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%ld\n", OLED.reverse_pixel);
+}
+
+static ssize_t reverse_store(struct class *class, struct class_attribute *attr,
+			const char *buf, size_t count)
+{
+	long l;
+	int ret;
+
+	ret = kstrtol(buf, 0, &l);
+	if (ret != 0 || l > 1 || l < 0)
+		return 0;
+	
+	printk(KERN_INFO "%s: reverse %ld\n", __func__, l);
+	OLED.reverse_pixel = l;
+	oled_flush();
+	return 2;
+}
+
+static CLASS_ATTR_RW(reverse);
+//static CLASS_ATTR(reverse, 0555, reverse_show, reverse_store);
+static struct class *oled_class;
+
+static int oled_ssd1308_probe(struct spi_device *spi)
+{
+	int ret;
+	unsigned int x, y;
+	struct oled_platform_data_t *pData;
+	ssize_t page_nr, fb;
+
+	if (!spi) {
+		printk(KERN_WARNING "%s: spi is null. Device is not accessible\n",
+		       __func__);
+		return -ENODEV;
+	}
+
+	spi->bits_per_word = 8;
+	ret = spi_setup(spi);
+	if (ret)
+		printk(KERN_WARNING  "%s: spi_setup() failed~\n", __func__);
+
+	pData = (struct oled_platform_data_t*)spi->dev.platform_data;
+	OLED = *pData;
+	pr_debug("%dx, %dy, %dreset, %dad, %p-spi\n",
+	       __func__,
+	       pData->pixel_x, pData->pixel_y,
+	       pData->reset_pin, pData->ad_pin, spi);
+
+	OLED.spi = spi;
+	pr_debug("spi_new_device(), 0x%lx successful~\n",
+	       __func__, (unsigned long)OLED.spi);
+
+	/* Allocate memory */
+	x = OLED.pixel_x;
+	y = OLED.pixel_y / OLED.page_nr;
+	OLED.fb_size = x * y;
+	fb = OLED.fb_size;
+	for (page_nr = 1; fb > PAGE_SIZE; page_nr++, fb -= PAGE_SIZE);
+	OLED.fb = kzalloc(PAGE_SIZE * page_nr, GFP_KERNEL);
+	OLED.fb_reverse = kmalloc(PAGE_SIZE * page_nr, GFP_KERNEL);
+
+	oled_init_gpios(&OLED);
+	oled_init(&OLED);
+
+	pr_debug("before misc_register", __func__);
+	ret = misc_register(&oled_ssd1308_miscdev);
+	if (ret >= 0) {
+		printk(KERN_INFO "%s: Register OLED miscdev successful!\n", __func__);
+		oled_class = class_create(THIS_MODULE, "oled");
+		if (IS_ERR(oled_class))
+			pr_warn("Unable to create OLED class; errno = %ld\n",
+				PTR_ERR(oled_class));
+		else
+			class_create_file(oled_class, &class_attr_reverse);
+	}
+	else
+		printk(KERN_WARNING "%s: Register OLED miscdev failed~\n", __func__);
+	
+	return ret;
+}
+
+static int oled_ssd1308_remove(struct spi_device *spi)
+{
+	class_remove_file(oled_class, &class_attr_reverse);
+	class_destroy(oled_class);
+	oled_off();
+	oled_free_gpios();
+	kfree(OLED.fb);
+	misc_deregister(&oled_ssd1308_miscdev);
+	printk(KERN_INFO "%s: Unregister ssd miscdev successful~\n", __func__);
+	return 0;
+}
+
+static const struct of_device_id oled_ssd1308_dt_ids[] = {
+	{ .compatible = "visionox,ssd1308" },
+	{}
+};
+
+MODULE_DEVICE_TABLE(of, oled_ssd1308_dt_ids);
+
+
+static struct spi_driver oled_ssd1308_driver = {
+	.driver = {
+		.name = "oled-ssd1308",
+		.owner = THIS_MODULE,
+		.of_match_table = oled_ssd1308_dt_ids
+	},
+	.probe = oled_ssd1308_probe,
+	.remove = oled_ssd1308_remove
+};
+
+
+module_spi_driver(oled_ssd1308_driver);
+MODULE_LICENSE("GPL");

--- a/student/oled_ssd1308_spi.h
+++ b/student/oled_ssd1308_spi.h
@@ -1,0 +1,50 @@
+/**************************************************************
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  
+ *
+ *
+ *  History:     ysh  7-17-2016          Create
+ *************************************************************/
+
+
+#ifndef __OLED_SSD1308_SPI_H
+#define __OLED_SSD1308_SPI_H
+
+
+#include <linux/types.h>
+#include <linux/semaphore.h>
+#include <linux/ioctl.h>
+
+
+struct oled_platform_data_t {
+	struct semaphore sem;
+	struct spi_device *spi;
+	unsigned int pixel_x;
+	unsigned int pixel_y;
+	unsigned int page_nr;
+	unsigned reset_pin;
+	unsigned ad_pin;
+	unsigned led1_pin;
+	unsigned led2_pin;
+	unsigned int fb_size;
+	u8 *fb;
+	long reverse_pixel;
+	u8 *fb_reverse;
+};
+
+
+void oled_reset(void);
+void oled_on(void);
+void oled_off(void);
+void oled_paint(u8 byte);
+void oled_flush(void);
+void oled_init(struct oled_platform_data_t *);
+
+
+#endif /* __OLED_SSD1308_SPI_H */

--- a/student/test-oled-ssd1308.c
+++ b/student/test-oled-ssd1308.c
@@ -1,0 +1,300 @@
+/**************************************************************
+ *  Name          :  test-oled-ssd1308.c
+ *  Author        :  
+ *                    ..  ..
+ *                   / | / |            ~~
+ *                  /  |/  |    /| \ /  ~
+ *                 /   | ~ |   /.|  x  ~
+ *                / ~      |~ /  l / L
+ *
+ *  Description :  Test driver : oled-ssd1308
+ *                 
+ *  
+ *  History:    ysh   7-28-2016          Create
+ *************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stropts.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <pthread.h>
+#include "oled_ssd1308_ioctl.h"
+
+
+sig_atomic_t child_exit_status;
+
+
+static void
+print_usage(FILE *stream)
+{
+	fprintf(stream, "\nUsage: OLED test utility\n");
+	fprintf(stream,
+		"SYSNOPSIS:\n"
+		"   test-oled-ssd1308\n"
+		"\t-c\tclear screen\n"
+		"\t-o\tturn on screen\n"
+		"\t-i\tturn off screen\n"
+		"\t-f feed-byte\tfeed screen with BYTE\n"
+		"\t-r\treset screen\n"
+		"\t-t\ttest times\n"
+		"\t-u\tflush rate (ms)\n"
+		"\t-m feed-byte\ttest mmap()\n"
+		);
+	
+	exit(0);
+}
+
+struct Threadpara_t {
+	int fd;
+	int row;
+	unsigned char feed;
+	pthread_t th_id;
+	pthread_mutex_t mutex;
+};
+
+
+static void*
+_thread_test_mmap(void *ptr)
+{
+	struct Threadpara_t *th = (struct Threadpara_t*)ptr;
+	size_t i, j, k, len = 128 * 64 / 8;
+	size_t
+		row_len = 128,
+		row_start = th->row * row_len,
+		row_end = row_start + row_len - 1;
+	size_t
+		grey_area = 0,
+		grey_area_width = 8,
+		grey_area_start = th->row * grey_area_width,
+		grey_area_end;
+
+	unsigned char *map;
+	bool quit;
+	const useconds_t _1s = 1000000;
+	unsigned char a, b;
+	
+	map = (unsigned char*)mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, th->fd, 0);
+	if (map == MAP_FAILED) {
+		printf("mmap() failed!\n");
+		return (void*)-1;
+	}
+
+	printf("map : %p, feed : 0x%X\n", map, th->feed);
+	k = th->row;
+	
+	for (quit = false; !quit;)
+	{		
+		if (pthread_mutex_trylock(&th->mutex) == 0)
+			quit = true;
+
+#if 0 /* Bar */
+		for (j = 0; j < len; j++) {
+			if (j == grey_area) {
+				size_t i = 0;
+				for (i = 0; i < 64; i++, j++)
+					map[j] = 0;
+			}
+			else {
+				map[j] = th->feed;
+			}
+		}
+
+		grey_area += 64;
+		if (grey_area >= len)
+			grey_area = 0;
+		
+#elif 0 /* Wave */
+
+		for (j=row_start; j<=row_end; j++)
+			map[j] = 0xff;
+
+		grey_area_start += grey_area_width;
+		grey_area_start %= row_len;
+		grey_area_end = grey_area_start + grey_area_width;
+
+		j = row_start + grey_area_start;
+		k = j + grey_area_width;
+
+		for (; j<k; j++)
+			map[j] = 0;
+		
+#else /* Chess board */
+		
+		j = row_start;
+		k++;
+		if (k % 2) {
+			a = th->feed;
+			b = 0;
+		}
+		else {
+			a = 0;
+			b = th->feed;
+		}
+		
+		for (; j<=row_end; j++) {
+			for (i=0; i<8; i++, j++)
+				map[j] = a;
+			
+			if (j >= row_end)
+				break;
+			
+			for (i=0; i<8; i++, j++)
+				map[j] = b;
+		}
+#endif
+
+		usleep(_1s);
+	}
+	
+	munmap(map, len);
+	printf("Thread (0x%lX) was terminated!\n", th->th_id);
+	return (void*)0;
+}
+
+
+void clean_up_child_proc(int sig_number, siginfo_t *info, void *p)
+{
+	/* Clean up the child process */
+	int status;
+	pid_t child_pid;
+	child_pid = wait(&status);
+
+	printf("%s: Child PID %d\n", __func__, child_pid);
+	child_exit_status = status;
+}
+
+
+int main(int argc, char *argv[])
+{
+	int
+		fd,
+		i,
+		opt;
+	char write_data[20] = { 0 };
+	ssize_t ret;
+	char *dev = "/dev/oled-ssd1308";
+	pid_t child;
+	struct sigaction sigchld_action;
+	const useconds_t _1s = 1000000;
+
+	/*
+	 * If child process completes earlier than parent process,
+	 * Child process becomes a zombie process, parent process has to
+	 * clean up child process by calling wait().
+	 */
+	memset(&sigchld_action, 0, sizeof(struct sigaction));
+	sigchld_action.sa_sigaction = clean_up_child_proc;
+	sigaction (SIGCHLD, &sigchld_action, NULL);
+
+#if 0
+	child = fork();
+	if (child == 0)
+		strcpy(write_data, "I'm a child");
+	else
+		strcpy(write_data, "I'm parent");
+#endif
+	
+	if ( (fd = open(dev, O_RDWR)) == -1 ) {
+		fprintf(stderr, "Open %s failed~\n", dev);
+		exit(EXIT_FAILURE);
+	}
+	
+	fprintf(stderr, "Open %s successful!\n", dev);
+
+	
+	while( (opt = getopt(argc, argv, ":rct:oif:u:m:")) != -1 )
+	{
+		switch(opt) {
+		case ':':
+		case '?': print_usage(stderr); break;
+		case 'c': ioctl(fd, OLED_CLEAR); break;
+		case 'o': ioctl(fd, OLED_ON); break;
+		case 'i': ioctl(fd, OLED_OFF); break;
+		case 'r': ioctl(fd, OLED_RESET); break;
+
+		case 'f':
+		{
+			unsigned char feed;
+			feed = (unsigned char)atoi(optarg);
+			ioctl(fd, OLED_FEED, &feed);
+			printf("Feed byte: 0x%X\n", feed);
+		}
+		break;
+			
+		case 't':
+		{
+			int run = atoi(optarg);
+			printf("Run test %d times\n", run);
+			for (i=0; i<run; i++) {
+				unsigned char b = (unsigned char)i;
+				ret = write(fd, &b, sizeof(unsigned char));
+				printf("%s : %d\n", __func__, i);
+				usleep(_1s / 2);
+			}
+		}
+		break;
+
+		case 'u':
+		{
+			unsigned long rate;
+			rate = (unsigned long)atoi(optarg);
+			ioctl(fd, OLED_FLUSH_RATE, rate);
+			printf("Flush rate : %lums\n", rate);
+		}
+		break;
+
+		case 'm':
+		{
+			int i, c;
+			const int thread_nr = 8;
+			struct Threadpara_t para[thread_nr];
+			unsigned char feed = (unsigned char)atoi(optarg);
+			int event;
+			
+			for (i=0; i<thread_nr; i++) {
+				para[i].fd = fd;
+				para[i].row = i;
+				para[i].feed = feed;
+				pthread_mutex_init(&para[i].mutex, NULL);
+				pthread_mutex_lock(&para[i].mutex);
+			}
+			
+			for (i=0; i<thread_nr; i++)
+				pthread_create(&para[i].th_id, NULL, &_thread_test_mmap, (void*)&para[i]);
+			
+			while ((c=getchar()) != 'a') {
+				printf("getchar() = %c\n", c);
+				usleep(_1s);
+			}
+			
+			for (i=0; i<thread_nr; i++)
+				pthread_mutex_unlock(&para[i].mutex);
+			
+			for (i=0; i<thread_nr; i++)
+				pthread_join(para[i].th_id, (void**)&event);
+
+			for (i=0; i<thread_nr; i++)
+				pthread_mutex_destroy(&para[i].mutex);
+		}
+		break;
+
+		default: break;
+		}
+	}
+	
+	printf("Press any key to quit!");
+	getchar();
+	close(fd);
+	
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Create a device drive for operating OLED (128 x 64)
Platform: TI AM3352, ARM Cortex A8
The resolution of OLED :  128 x 64 pixel, to plot OLED, device driver provides  mmap operation.
Device node: /dev/oled-ssd1308
The test program: test-oled-ssd1308.c
Known issue: when running test program (test-oled-ssd1308), system average load rise to 1.0 1.0 1.0
